### PR TITLE
Tighten Button Hover And Table Header Icon Spacing

### DIFF
--- a/packages/react/src/components/Button/ButtonStyles.module.css
+++ b/packages/react/src/components/Button/ButtonStyles.module.css
@@ -31,10 +31,6 @@
   background-color: transparent !important;
 }
 
-.button[data-hovered]:not([data-disabled]) svg {
-  background: var(--btn-hover-bg, inherit);
-}
-
 .button[data-pressed]:not([data-disabled]) {
   cursor: pointer;
 }

--- a/packages/react/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/components/Button/__tests__/Button.test.tsx
@@ -109,6 +109,14 @@ describe("<Button />", () => {
       expect(buttonStylesSource).toContain("var(--cui-transition-color)")
     })
 
+    it("keeps hover background styles on the root button instead of child icons.", () => {
+      expect(buttonStylesSource).toContain(
+        ".button[data-hovered]:not(.button--transparent, [data-disabled]) {\n  background-color: var(--btn-hover-bg, var(--btn-bg));",
+      )
+      expect(buttonStylesSource).toContain(".button svg {\n  background: transparent;")
+      expect(buttonStylesSource).not.toContain(".button[data-hovered]:not([data-disabled]) svg")
+    })
+
     it("keeps fill order styles on semantic action foreground/background pairs.", () => {
       expect(buttonStylesSource).toContain(
         ".button--primary--fill {\n  background-color: var(--cui-action-primary-background);\n  color: var(--cui-action-primary-foreground)",

--- a/packages/react/src/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/react/src/components/Table/components/TableHeader/TableHeader.tsx
@@ -91,7 +91,7 @@ const TableHeader = <T extends object>(props: TTableHeaderProps<T>) => {
 
         const nameText = (
           <Text
-            customClassName={classNames(hiddenStyle, column.customHeaderCellClassName)}
+            customClassName={classNames(styles.tableHeader__cellLabel, hiddenStyle, column.customHeaderCellClassName)}
             customStyles={{ ...column.customHeaderCellStyles }}
             elementType="span"
             variant="b10"

--- a/packages/react/src/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/react/src/components/Table/components/TableHeader/TableHeader.tsx
@@ -100,6 +100,47 @@ const TableHeader = <T extends object>(props: TTableHeaderProps<T>) => {
             {column.name ?? ""}
           </Text>
         )
+        const filterControl = columnAllowsFiltering ? (
+          filteringMode === TABLE_FILTERING_CONTROL_MODE__POPOVER && filteringControls?.onFiltersChange ? (
+            <TableFilterPopover<T>
+              column={column}
+              filterGroup={activeFilterGroup}
+              activeFilters={filteringControls.activeFilters}
+              onFiltersChange={filteringControls.onFiltersChange}
+              isFilterActive={isFilterActive}
+              activeFilterIcon={activeFilterIcon}
+              inactiveFilterIcon={inactiveFilterIcon}
+              triggerClassName={filterButtonClassName}
+              labels={filteringLabels}
+            />
+          ) : (
+            <button
+              type="button"
+              aria-label={filteringLabels.popover.triggerButtonAriaLabel({
+                criteriaName: column.name ?? column.id,
+              })}
+              aria-pressed={isFilterActive}
+              className={filterButtonClassName}
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation()
+                filteringControls?.onFilterIconPress?.({
+                  columnID: column.id,
+                  columnName: column.name ?? column.id,
+                  filterGroup: activeFilterGroup,
+                })
+              }}
+            >
+              {isFilterActive ? activeFilterIcon : inactiveFilterIcon}
+            </button>
+          )
+        ) : null
+        const sortIndicator =
+          columnAllowsSorting && sortDirection ? (
+            <span aria-hidden="true" className={styles.tableHeader__sortIndicator}>
+              {sortDirection === TABLE_SORT_DIRECTION__ASCENDING ? ascendingIcon : descendingIcon}
+            </span>
+          ) : null
 
         return (
           <TableColumn
@@ -124,46 +165,10 @@ const TableHeader = <T extends object>(props: TTableHeaderProps<T>) => {
             {needsInnerWrapper ? (
               <div className={styles.tableHeader__cellInner}>
                 {nameText}
-                {columnAllowsFiltering && (
-                  <>
-                    {filteringMode === TABLE_FILTERING_CONTROL_MODE__POPOVER && filteringControls?.onFiltersChange ? (
-                      <TableFilterPopover<T>
-                        column={column}
-                        filterGroup={activeFilterGroup}
-                        activeFilters={filteringControls.activeFilters}
-                        onFiltersChange={filteringControls.onFiltersChange}
-                        isFilterActive={isFilterActive}
-                        activeFilterIcon={activeFilterIcon}
-                        inactiveFilterIcon={inactiveFilterIcon}
-                        triggerClassName={filterButtonClassName}
-                        labels={filteringLabels}
-                      />
-                    ) : (
-                      <button
-                        type="button"
-                        aria-label={filteringLabels.popover.triggerButtonAriaLabel({
-                          criteriaName: column.name ?? column.id,
-                        })}
-                        aria-pressed={isFilterActive}
-                        className={filterButtonClassName}
-                        onPointerDown={(e) => e.stopPropagation()}
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          filteringControls?.onFilterIconPress?.({
-                            columnID: column.id,
-                            columnName: column.name ?? column.id,
-                            filterGroup: activeFilterGroup,
-                          })
-                        }}
-                      >
-                        {isFilterActive ? activeFilterIcon : inactiveFilterIcon}
-                      </button>
-                    )}
-                  </>
-                )}
-                {columnAllowsSorting && sortDirection && (
-                  <span aria-hidden="true" className={styles.tableHeader__sortIndicator}>
-                    {sortDirection === TABLE_SORT_DIRECTION__ASCENDING ? ascendingIcon : descendingIcon}
+                {(filterControl || sortIndicator) && (
+                  <span className={styles.tableHeader__iconGroup}>
+                    {filterControl}
+                    {sortIndicator}
                   </span>
                 )}
               </div>

--- a/packages/react/src/components/Table/components/TableHeader/TableHeaderStyles.module.css
+++ b/packages/react/src/components/Table/components/TableHeader/TableHeaderStyles.module.css
@@ -42,6 +42,8 @@
 }
 
 .tableHeader__cellLabel {
+  display: block;
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/react/src/components/Table/components/TableHeader/TableHeaderStyles.module.css
+++ b/packages/react/src/components/Table/components/TableHeader/TableHeaderStyles.module.css
@@ -17,11 +17,6 @@
   text-align: center;
 }
 
-.tableHeader__cell--alignCenter > * {
-  display: block;
-  width: 100%;
-}
-
 .tableHeader__cell--alignEnd {
   text-align: end;
 }
@@ -31,9 +26,26 @@
 }
 
 .tableHeader__cellInner {
-  display: inline-flex;
+  width: 100%;
+  min-width: 0;
+  display: flex;
   align-items: center;
   gap: var(--cui-space-1);
+}
+
+.tableHeader__cell--alignCenter .tableHeader__cellInner {
+  justify-content: center;
+}
+
+.tableHeader__cell--alignEnd .tableHeader__cellInner {
+  justify-content: flex-end;
+}
+
+.tableHeader__cellLabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tableHeader__sortIndicator {

--- a/packages/react/src/components/Table/components/TableHeader/TableHeaderStyles.module.css
+++ b/packages/react/src/components/Table/components/TableHeader/TableHeaderStyles.module.css
@@ -50,6 +50,14 @@
   white-space: nowrap;
 }
 
+.tableHeader__iconGroup {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: var(--cui-space-1);
+  min-width: 0;
+}
+
 .tableHeader__sortIndicator {
   display: flex;
   align-items: center;

--- a/packages/react/verify-button-proof.mjs
+++ b/packages/react/verify-button-proof.mjs
@@ -133,6 +133,10 @@ requiredStyleSelectors.forEach((selector) => {
   assert(stylesSource.includes(cssValue), `Button CSS must read ${cssValue}`)
 })
 assert(!forbiddenLegacyCssPattern.test(stylesSource), "Button CSS must not read legacy Wavemap aliases")
+assert(
+  !stylesSource.includes(".button[data-hovered]:not([data-disabled]) svg"),
+  "Button hover background must stay on the root button instead of child SVGs",
+)
 
 requiredActionColorVariables.forEach((cssVariable) => {
   assert(actionColorsSource.includes(cssVariable), `action-colors CSS must define ${cssVariable}`)


### PR DESCRIPTION
## Summary

  - Fixes icon-button hover styling so hover background behavior belongs to the button root instead of only filling the icon viewbox.
  - Adds Button coverage/proof updates for root hover behavior.
  - Tightens Table header label/icon layout so filter icons sit one spacing step from the column label and active sort icons render one spacing step to the right.
  - Keeps table header labels shrinkable/truncatable so filter and sort controls do not overlap narrow column names.

  ## Verification

  - `pnpm -F @codon-ui/react typecheck`
  - `pnpm -F @codon-ui/react stylelint`
  - `pnpm -F @codon-ui/react exec node verify-table-proof.mjs`
  - Pre-commit for the staged React package ran format, lint, stylelint, registry contract checks, and typecheck.

  ## Notes

  - Target branch: `develop`
  - Consumer mirrors were applied in Waveguide and Wavemap after this source-of-truth update.